### PR TITLE
feat: add table name option to Insert function

### DIFF
--- a/pmx_insert_test.go
+++ b/pmx_insert_test.go
@@ -83,6 +83,16 @@ func (s *InsertSuite) TestUniqueViolation() {
 	s.True(pmx.UniqueViolation(err))
 }
 
+func (s *InsertSuite) TestCustomTableName() {
+	user := test.User{
+		Name: "Elon",
+	}
+
+	tag, err := pmx.Insert(context.Background(), s.conn, &user, pmx.TableName("users"))
+	s.Equal(pgconn.NewCommandTag("INSERT 0 1"), tag)
+	s.NoError(err)
+}
+
 func (s *InsertSuite) TestStructValue() {
 	var projection test.Projection
 	tag, err := pmx.Insert(context.Background(), s.conn, projection)

--- a/test/schema.go
+++ b/test/schema.go
@@ -20,6 +20,10 @@ var statements = []string{
 		metadata jsonb,
 		slice jsonb
 	)`,
+
+	`create table users (
+		name varchar
+	)`,
 }
 
 type Event struct {
@@ -35,6 +39,10 @@ type Projection struct {
 	Slice             []string       `db:"slice"`
 	ExportedTransient string
 	privateTransient  string
+}
+
+type User struct {
+	Name string `db:"name"`
 }
 
 func init() {


### PR DESCRIPTION
**Description:** This PR introduces an option to specify the table name in the Insert function through an additional parameter TableName. This enhancement is particularly useful in cases where structs are generated automatically (e.g., using sqlc), and adding annotations is not feasible.

**Changes:**

Added TableName option function for specifying the table name in the Insert function.
Enhanced Insert to accept options (opts ...option) and utilize the specified table name if provided.
Added error handling for cases where the table name is empty.

**Benefits:** This update allows greater flexibility in specifying table names for dynamically generated structs, facilitating usage with automated code generation tools.

**Further Support:** If this solution is suitable, I am available to update the documentation or make further improvements as needed.